### PR TITLE
히스토리 나열 작업 - 히스토리 이어 붙일 때 발생하는 버그 해결

### DIFF
--- a/client/component/MenuBar/History.js
+++ b/client/component/MenuBar/History.js
@@ -93,6 +93,7 @@ export default class History {
   }
 
   render() {
+    this.$history?.remove();
     this.$history = document.createElement("div");
     this.$history.className = "history";
     this.$target.appendChild(this.$history);


### PR DESCRIPTION
<!-- 중요한 내용들, 추가적인 기술, 구현 방법 -->

## 세부사항
히스토리 엘리먼트가 여러 개 DOM에 생성되는 버그를 식별했습니다.
히스토리 데이터가 업데이트가 되면, 히스토리 엘리먼트를 지우고 다시 그려내도록 해서 해결했습니다.


<!-- 팀원에게 하고싶은 말 -->

## 참고 사항

- #14
